### PR TITLE
feat: Implement contract usage tracking on generation

### DIFF
--- a/backend/src/routes/contracts.js
+++ b/backend/src/routes/contracts.js
@@ -9,23 +9,47 @@ module.exports = (pool) => {
         if (!req.body || !req.body.parameters || !req.body.options || !req.body.parameters.title) {
             return res.status(400).json({ error: 'Invalid request payload. Missing title, parameters, or options.' });
         }
+        
+        const userId = req.user.userId;
+        const userInput = req.body;
+
         try {
-            const userInput = req.body;
-            const userId = req.user.userId;
+            // 1. Generate the contract content using the composer engine.
             const contractContent = await composeContract(userInput);
-            const newContract = await pool.query(
+
+            // 2. Save the newly generated contract to the database.
+            const newContractResult = await pool.query(
                 'INSERT INTO contracts (user_id, title, contract_type, content) VALUES ($1, $2, $3, $4) RETURNING *',
                 [userId, userInput.parameters.title, userInput.contractType, contractContent]
             );
+            const savedContract = newContractResult.rows[0];
+
+            // --- CHANGE START ---
+            // 3. Atomically increment the user's usage count for the month.
+            // This is a "fire and forget" operation. We log errors but do not fail the
+            // overall request, as the user has already received their contract.
+            pool.query(
+                'UPDATE users SET contracts_used_this_month = contracts_used_this_month + 1 WHERE id = $1',
+                [userId]
+            ).catch(err => {
+                // If this fails, it's an internal issue but not critical to the user's flow.
+                // We log it for maintenance purposes.
+                console.error(`Failed to increment usage count for user ${userId}:`, err);
+            });
+            // --- CHANGE END ---
+
+            // 4. Return the successful response to the user.
             res.status(200).json({
                 message: "Contract generated and saved successfully.",
                 contract: contractContent,
-                savedContract: newContract.rows[0]
+                savedContract: savedContract
             });
+
         } catch (error) {
             console.error('Contract generation or saving failed:', error);
             res.status(500).json({ error: 'An unexpected error occurred while processing the contract.' });
         }
     });
+
     return router;
 };


### PR DESCRIPTION
This pull request implements Phase 1, Task 2 of the official operational plan. It introduces backend logic to track user activity by incrementing a monthly usage counter each time a new contract is successfully generated.
This is a critical prerequisite for future subscription and monetization features, allowing us to enforce plan limits (e.g., "5 contracts per month").

**Key Changes**
src/routes/contracts.js:
The /api/generate-contract endpoint has been modified.

After the new contract is successfully inserted into the contracts table, a second query is executed.
This new query performs an atomic update on the users table: UPDATE users SET contracts_used_this_month = contracts_used_this_month + 1 WHERE id = $1.

Using an atomic operation (... + 1) directly in the SQL query prevents race conditions if multiple requests are made by the same user simultaneously.

The update operation is wrapped in a .catch() block to ensure that any failure in incrementing the counter does not prevent the user from receiving their generated contract, logging the error for internal review instead.

**How to Verify**
Log in to the application while monitoring the Network tab in browser developer tools.
Inspect the response from the /api/login request and note the initial value of user.contracts_used_this_month.
Navigate to the Create Contract page and generate a new contract.
After successful generation, log out.
Log in again with the same user.
Inspect the response from the new /api/login request. The value of user.contracts_used_this_month should now be incremented by 1.
Verify on the Dashboard that the "This Month" card reflects the new, incremented value.