### PR TITLE
feat: make API_BASE_URL configurable via VITE_API_BASE_URL env var wi…

### DIFF
--- a/backend/PHASES.md
+++ b/backend/PHASES.md
@@ -131,3 +131,8 @@ Status: ✅ Done | 🚧 In Progress | ⏳ Planned
 - Navigate-after-generate → `/contracts/${id}`
 
 **Next:** Phase 1.5 — Deploy (Backend: Railway, Frontend: Vercel, SSL/Domain)
+
+## Phase 1.5 — Deployment — 2025-08-13
+- Backend: env validation present (backend/config/env.js); DB via `DATABASE_URL`, SSL via `PGSSL`.
+- Frontend: reads `import.meta.env.VITE_API_BASE_URL`; no other functional changes.
+- Next: deploy backend to Railway, set env, then point Vercel to Railway URL.

--- a/backend/PROGRESS.md
+++ b/backend/PROGRESS.md
@@ -17,3 +17,8 @@
 - No files replaced wholesale; only a single-line insert via awk and a new file added.
 - Conflict markers found in server.js were surgically removed (backup: server.js.pre-mergefix).
 \n## Security Implementation - Phase 1.2.1\n**Date:** Mon Aug 11 22:50:10 CEST 2025\n**Branch:** feat/security-logging\n\n✅ **Helmet Security Headers** - XSS protection, clickjacking protection, HSTS\n✅ **Morgan Request Logging** - Combined format for production monitoring\n✅ **Joi Environment Validation** - Startup validation of all required env vars\n✅ **Database Security** - Moved from hardcoded credentials to environment variables\n\n**Testing:** Server starts successfully with all security middleware active\n**Commit:** e5ecdc0
+
+### 2025-08-13 — Phase 1.5 Deployment (prep committed)
+- Frontend: API_BASE_URL now configurable via `VITE_API_BASE_URL` (fallback http://localhost:5000).
+- Env: `.env.example` lists required keys (DATABASE_URL, PGSSL, OPENAI_API_KEY, GOOGLE_AI_API_KEY, JWT_SECRET, CORS_ORIGIN, PORT).
+- Status: ready to deploy backend → Railway and wire frontend → Vercel.

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,9 +1,7 @@
 // Frontend configuration for VibeLegal
 const config = {
   // API Base URL - update this when you deploy your backend
-  API_BASE_URL: process.env.NODE_ENV === 'production' 
-    ? 'https://your-backend-app.herokuapp.com'  // Replace with your actual backend URL
-    : 'http://localhost:5000',
+  API_BASE_URL: (typeof import !== "undefined" && typeof import.meta !== "undefined" && import.meta.env && import.meta.env.VITE_API_BASE_URL) ? import.meta.env.VITE_API_BASE_URL : "http://localhost:5000",
     
   // App configuration
   APP_NAME: 'VibeLegal',


### PR DESCRIPTION
**Phase 1.5 — Deployment Prep**

Frontend

API_BASE_URL now reads from VITE_API_BASE_URL if set, otherwise defaults to http://localhost:5000.

Makes it easy to point frontend at deployed backend without code changes.

Env

.env.example updated with all required backend keys:

DATABASE_URL

PGSSL

OPENAI_API_KEY

GOOGLE_AI_API_KEY

JWT_SECRET

CORS_ORIGIN

PORT

**Status**

Ready to deploy backend to Railway, configure env vars there.

Then set VITE_API_BASE_URL in Vercel to Railway backend URL.