### PR TITLE
feat: add consistent JSON 404 handler before error middleware

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -290,7 +290,12 @@ app.get('/api/contracts/:id', authenticateToken, async (req, res) => {
   }
 });
 
-// --- Error Handler (must be last) ---
+app.use("*", (req, res) => {
+  res.status(404).json({
+    requestId: req.id || undefined,
+    error: { code: "NOT_FOUND", message: `Cannot ${req.method} ${req.originalUrl}` }
+  });
+});// --- Error Handler (must be last) ---
 app.use(errorHandler);
 // --- Server Startup (single listener) ---
 const server = app.listen(PORT, () => {


### PR DESCRIPTION
Adds a JSON 404 handler to ensure all unknown routes return a consistent error payload.

**Details**

Placed just before the centralized error handler in server.js

Returns HTTP 404 with payload:

{
  "requestId": "<uuid or undefined>",
  "error": { "code": "NOT_FOUND", "message": "Cannot GET /path" }
}


Supports request ID when available

Eliminates Express default HTML “Cannot GET …” output

Why
Keeps API error responses consistent for frontend consumers, improves DX, and avoids leaking Express defaults in production.

**Testing**

Verified locally with curl http://localhost:5000/api/doesnotexist returns JSON 404

Server boots clean without errors